### PR TITLE
Add contract zone API endpoint

### DIFF
--- a/areas/tests/conftest.py
+++ b/areas/tests/conftest.py
@@ -1,1 +1,2 @@
 from common.tests.conftest import *  # noqa
+from users.tests.conftest import *  # noqa

--- a/areas/tests/test_contract_zone_api.py
+++ b/areas/tests/test_contract_zone_api.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+import pytest
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.utils.timezone import make_aware
+from rest_framework.reverse import reverse
+
+from common.tests.utils import get
+from events.factories import EventFactory
+
+from ..factories import ContractZoneFactory
+
+LIST_URL = reverse('v1:contractzone-list')
+
+
+@pytest.fixture
+def contract_zone():
+    return ContractZoneFactory(boundary=MultiPolygon(Polygon((
+        (24, 60),
+        (25, 60),
+        (25, 61),
+        (24, 61),
+        (24, 60),
+    ))))
+
+
+@pytest.fixture
+def two_events_2018():
+    return EventFactory.create_batch(2)
+
+
+@pytest.fixture
+def two_events_2019():
+    return EventFactory.create_batch(2, start_time=make_aware(datetime(2019, 3, 3)))
+
+
+def get_expected_base_data(contract_zone):
+    return {
+        'id': contract_zone.id,
+        'name': contract_zone.name,
+    }
+
+
+def test_get_list_non_official_no_stats(contract_zone, two_events_2018, user_api_client):
+    response_data = get(user_api_client, LIST_URL + '?stats_year=2018')
+
+    assert response_data['results'] == [get_expected_base_data(contract_zone)]
+
+
+def test_get_list_official_no_filter_no_stats(contract_zone, two_events_2018, official_api_client):
+    response_data = get(official_api_client, LIST_URL)
+
+    assert response_data['results'] == [get_expected_base_data(contract_zone)]
+
+
+def test_get_list_official_check_stats(contract_zone, two_events_2018, two_events_2019, official_api_client):
+    response_data = get(official_api_client, LIST_URL + '?stats_year=2018')
+
+    event_1, event_2 = two_events_2018
+    expected_data = dict(
+        get_expected_base_data(contract_zone),
+        event_count=2,
+        estimated_attendee_count=event_1.estimated_attendee_count + event_2.estimated_attendee_count,
+    )
+    assert response_data['results'] == [expected_data]

--- a/haravajarjestelma/settings.py
+++ b/haravajarjestelma/settings.py
@@ -103,6 +103,7 @@ INSTALLED_APPS = [
     'rest_framework_gis',
     'corsheaders',
     'munigeo',
+    'django_filters',
 
     'events',
     'users',
@@ -160,6 +161,9 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
     'DEFAULT_AUTHENTICATION_CLASSES': ('helusers.oidc.ApiTokenAuthentication',),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+    ),
 }
 
 # local_settings.py can be used to override settings

--- a/haravajarjestelma/urls.py
+++ b/haravajarjestelma/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from areas.api import GeoQueryViewSet, NeighborhoodViewSet
+from areas.api import ContractZoneViewSet, GeoQueryViewSet, NeighborhoodViewSet
 from events.api import EventViewSet
 from users.api import UserViewSet
 
@@ -11,6 +11,7 @@ router.register('event', EventViewSet)
 router.register('neighborhood', NeighborhoodViewSet, basename='neighborhood')
 router.register('geo_query', GeoQueryViewSet, basename='geo_query')
 router.register('user', UserViewSet)
+router.register('contract_zone', ContractZoneViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,4 @@ django-helusers
 djangorestframework-gis
 django-munigeo
 django-parler-rest
+django-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 django-cors-headers==2.4.0
 django-environ==0.4.5
+django-filter==2.1.0
 django-helusers==0.4.2
 django-js-asset==1.1.0    # via django-mptt
 django-mptt==0.9.1        # via django-munigeo

--- a/users/models.py
+++ b/users/models.py
@@ -11,3 +11,7 @@ class User(AbstractUser):
     contract_zones = models.ManyToManyField(
         ContractZone, verbose_name=_('contract zones'), related_name='contractors', blank=True
     )
+
+
+def can_view_contract_zone_details(user):
+    return user.is_authenticated and user.is_official


### PR DESCRIPTION
Officials can request also contract zones' event and attendee counts by using
query parameter `stats_year=<year>`.

Refs #27 