### PR TITLE
Add contract zone and its unavailable dates to geo query data

### DIFF
--- a/areas/models.py
+++ b/areas/models.py
@@ -1,8 +1,19 @@
+from collections import defaultdict
+from datetime import timedelta
+
+import holidays
+from django.conf import settings
 from django.contrib.gis.db import models
+from django.utils.timezone import localtime, now
 from django.utils.translation import ugettext_lazy as _
 from munigeo.utils import get_default_srid
 
 PROJECTION_SRID = get_default_srid()
+
+ONE_DAY = timedelta(days=1)
+SATURDAY = 6
+SUNDAY = 7
+HOLIDAYS_FINLAND = holidays.Finland()
 
 
 class ContractZone(models.Model):
@@ -16,3 +27,67 @@ class ContractZone(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_unavailable_dates(self):
+        """
+        Return a list of dates for which it is not possible to create an Event ATM.
+        """
+        today = localtime(now()).date()
+        last_too_early_day = today + timedelta(days=settings.EVENT_MINIMUM_DAYS_BEFORE_START)
+        too_early_dates = {date for date in date_range(today, last_too_early_day)}
+
+        events = self.events.filter(start_time__date__gt=last_too_early_day)
+        day_event_map = defaultdict(set)
+
+        for event in events:
+            for date in date_range(localtime(event.start_time).date(), localtime(event.end_time).date()):
+                for affected_date in get_affected_dates(date):
+                    day_event_map[affected_date].add(event)
+
+        too_many_events_dates = {
+            date
+            for date, events in day_event_map.items()
+            if len(events) >= settings.EVENT_MAXIMUM_COUNT_PER_CONTRACT_ZONE
+        }
+
+        return list(sorted(too_early_dates | too_many_events_dates))
+
+
+def get_affected_dates(date):
+    """
+    Return a list of all the dates in the "vacation day group" the given date belongs to
+
+    The root need is that we have to calculate how many events there are on a specific
+    day. Because contractors don't work on weekends or other vacation days, events on
+    those days need to be added to closest preceding non-vacation day's event count.
+    So this function returns all dates that are affected and therefore considered to be
+    in the same "group" as the given date.
+
+    Hopefully these couple of examples explain this a bit better (the examples have
+    weekday names instead of actual dates to make it more simple):
+
+    For a normal business day, this this will return just that day, Mon -> [Mon]
+    For Fri, Sat or Sun, this this will return [Fri, Sat, Sun].
+    For Mon or Tue when Tue is a national holiday, this this will return [Mon, Tue]
+    For Thu, Fri, Sat, Sun or next week Mon when Thu, Fri and next week Mon are
+    national holidays, this this will return [Thu, Fri, Sat, Sun, next week Mon]
+    """
+    start_date = end_date = date
+
+    while is_vacation_day(start_date):
+        start_date -= ONE_DAY
+    while is_vacation_day(end_date + ONE_DAY):
+        end_date += ONE_DAY
+
+    return [d for d in date_range(start_date, end_date)]
+
+
+def date_range(start, end):
+    current = start
+    while current <= end:
+        yield current
+        current += ONE_DAY
+
+
+def is_vacation_day(date):
+    return date.isoweekday() in (SATURDAY, SUNDAY) or date in HOLIDAYS_FINLAND

--- a/areas/tests/test_geo_query_api.py
+++ b/areas/tests/test_geo_query_api.py
@@ -1,10 +1,18 @@
+from datetime import date, datetime, timedelta
+
 import pytest
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
+from django.utils.timezone import localtime, make_aware, now
+from freezegun import freeze_time
 from rest_framework.reverse import reverse
 
 from common.tests.utils import check_translated_field_data_matches_object, get
+from events.factories import EventFactory
 
-from ..factories import AddressFactory, NeighborhoodFactory, SubDistrictFactory
+from ..factories import (
+    AddressFactory, ContractZoneFactory, NeighborhoodFactory,
+    SubDistrictFactory
+)
 from .test_neighborhood_api import check_division_data_matches_object
 
 URL = reverse('v1:geo_query-list')
@@ -26,6 +34,20 @@ def check_address_data_matches_object(address_data, address_obj):
     street_data = address_data['street']
     assert set(street_data.keys()) == {'name'}
     check_translated_field_data_matches_object(street_data, address_obj.street, 'name')
+
+
+@pytest.fixture(autouse=True)
+def set_frozen_time():
+    freezer = freeze_time('2018-11-01T08:00:00Z')
+    freezer.start()
+    yield
+    freezer.stop()
+
+
+@pytest.fixture(autouse=True)
+def override_settings(settings):
+    settings.EVENT_MINIMUM_DAYS_BEFORE_START = 7
+    settings.EVENT_MAXIMUM_COUNT_PER_CONTRACT_ZONE = 3
 
 
 @pytest.fixture
@@ -54,6 +76,17 @@ def sub_district():
 @pytest.fixture
 def addresses():
     return [AddressFactory(location=Point((lon, 60))) for lon in (24, 27, 30)]
+
+
+@pytest.fixture
+def contract_zone():
+    return ContractZoneFactory(boundary=MultiPolygon(Polygon((
+        (24, 60),
+        (25, 60),
+        (25, 61),
+        (24, 61),
+        (24, 60),
+    ))))
 
 
 def test_required_parameters(api_client):
@@ -92,3 +125,59 @@ def test_closest_address_check_data(api_client, addresses):
 def test_neighborhood_borders_count_also(api_client, neighborhoods):
     response_data = get(api_client, get_url(60, 24))
     check_division_data_matches_object(response_data['neighborhood'], neighborhoods[0])
+
+
+def test_no_matching_contract_zone(api_client, contract_zone):
+    response_data = get(api_client, get_url(67, 24.5))
+    assert response_data['contract_zone'] is None
+
+
+def test_contract_zone_check_data(api_client, contract_zone):
+    response_data = get(api_client, get_url(60, 24))
+    contract_zone_data = response_data['contract_zone']
+    assert contract_zone_data.keys() == {'id', 'name', 'unavailable_dates'}
+    assert contract_zone_data['id'] == contract_zone.id
+    assert contract_zone_data['name'] == contract_zone.name
+    assert contract_zone_data['unavailable_dates']
+
+
+def test_too_early_days_included_in_unavailable_dates(api_client, contract_zone):
+    today = localtime(now()).date()
+
+    response_data = get(api_client, get_url(60, 24))
+    dates = response_data['contract_zone']['unavailable_dates']
+
+    return dates == [
+        today,
+        today + timedelta(days=1),
+        today + timedelta(days=2),
+        today + timedelta(days=3),
+        today + timedelta(days=4),
+        today + timedelta(days=5),
+        today + timedelta(days=6),
+        today + timedelta(days=7),
+    ]
+
+
+@pytest.mark.parametrize('event_days, expected_unavailable_days', [
+    ([10, 10], []),  # normal Monday
+    ([9, 9], []),  # Sunday
+    ([6, 6], []),  # holiday
+    ([5, 6, 6], [5, 6]),  # 6 = holiday
+    ([10, 10, 10], [10]),  # max num of events is 3
+    ([14, 14, 14], [14, 15, 16]),  # 14 = Friday
+    ([14, 15, 16], [14, 15, 16]),
+    ([21, 22, 23], [21, 22, 23, 24, 25, 26]),  # 21 = Friday, 24-26 holidays
+])
+def test_unavailable_dates(api_client, contract_zone, event_days, expected_unavailable_days):
+    """
+    Test how event dates in December 2018 yield unavailable dates (too early dates ignored)
+    """
+    for event_day in event_days:
+        d = make_aware(datetime(2018, 12, event_day, 11))
+        EventFactory(start_time=d, end_time=d + timedelta(hours=1))
+
+    response_data = get(api_client, get_url(60, 24))
+    dates = response_data['contract_zone']['unavailable_dates'][8:]
+
+    assert dates == [date(2018, 12, d) for d in expected_unavailable_days]

--- a/haravajarjestelma/settings.py
+++ b/haravajarjestelma/settings.py
@@ -37,6 +37,7 @@ env = environ.Env(
     TOKEN_AUTH_FIELD_FOR_CONSENTS=(str, ''),
     TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, True),
     EVENT_MINIMUM_DAYS_BEFORE_START=(int, 7),
+    EVENT_MAXIMUM_COUNT_PER_CONTRACT_ZONE=(int, 3),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -78,7 +79,7 @@ LANGUAGES = (
     ('en', _('English')),
     ('sv', _('Swedish'))
 )
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Helsinki'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
@@ -144,6 +145,7 @@ AUTH_USER_MODEL = 'users.User'
 DEFAULT_SRID = 4326
 
 EVENT_MINIMUM_DAYS_BEFORE_START = env('EVENT_MINIMUM_DAYS_BEFORE_START')
+EVENT_MAXIMUM_COUNT_PER_CONTRACT_ZONE = env('EVENT_MAXIMUM_COUNT_PER_CONTRACT_ZONE')
 
 CORS_ORIGIN_WHITELIST = env('CORS_ORIGIN_WHITELIST')
 CORS_ORIGIN_ALLOW_ALL = env('CORS_ORIGIN_ALLOW_ALL')

--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ djangorestframework-gis
 django-munigeo
 django-parler-rest
 django-filter
+holidays

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,14 +22,16 @@ djangorestframework-gis==0.14
 djangorestframework==3.9.0
 drf-oidc-auth==0.9        # via django-helusers
 future==0.17.1            # via pyjwkest
+holidays==0.9.9
 idna==2.8                 # via requests
 psycopg2-binary==2.7.6.1
 pycryptodomex==3.7.2      # via pyjwkest
 pyjwkest==1.4.0           # via drf-oidc-auth
+python-dateutil==2.7.5    # via holidays
 pytz==2018.7              # via django
 pyyaml==3.13              # via django-munigeo
 raven==6.9.0
 requests-cache==0.4.13    # via django-munigeo
 requests==2.21.0          # via django-helusers, django-munigeo, pyjwkest, requests-cache
-six==1.12.0               # via django-munigeo, pyjwkest
+six==1.12.0               # via django-munigeo, holidays, pyjwkest, python-dateutil
 urllib3==1.24.1           # via requests


### PR DESCRIPTION
Added matching contract zone's data to geo query result. The data also includes
"unavailable_dates" field, which contains the dates in the future (including
the current day) for which creating a new event isn't possible. Possible
reasons for unavailability:
  * The date is too few days in the future
  * The date is on a day that is already full