### PR TITLE
Validate created event's dates against its zone's unavailable dates

### DIFF
--- a/common/tests/conftest.py
+++ b/common/tests/conftest.py
@@ -18,8 +18,9 @@ def set_frozen_time():
 
 
 @pytest.fixture(autouse=True)
-def force_english(settings):
+def force_settings(settings):
     settings.LANGUAGE_CODE = 'en'
+    settings.EVENT_MINIMUM_DAYS_BEFORE_START = 7
 
 
 @pytest.fixture(autouse=True)

--- a/events/api.py
+++ b/events/api.py
@@ -1,11 +1,8 @@
-from datetime import datetime, time, timedelta
-
-from django.conf import settings
-from django.utils import timezone
+from django.utils.timezone import localtime
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers, viewsets
 
-from areas.models import ContractZone
+from areas.models import ContractZone, date_range
 from events.models import ERROR_MSG_NO_CONTRACT_ZONE, Event
 
 
@@ -18,23 +15,24 @@ class EventSerializer(serializers.ModelSerializer):
     def validate(self, data):
         start_time = data.get('start_time')
         end_time = data.get('end_time')
-        now = timezone.now()
 
         # PATCH updates only 'state', so check that start and end times are present in the data
         if (start_time and end_time) and (start_time > end_time):
             raise serializers.ValidationError(_('Event must start before ending.'))
-
-        min_days = settings.EVENT_MINIMUM_DAYS_BEFORE_START
-        beginning_of_today = datetime.combine(now.date(), time(), tzinfo=now.tzinfo)
-        if start_time and (start_time < beginning_of_today + timedelta(days=min_days+1)):
-            error_msg = _('Event cannot start earlier than {} full days from now.').format(min_days)
-            raise serializers.ValidationError(error_msg)
 
         location = data.get('location')
         if location:
             data['contract_zone'] = ContractZone.objects.get_by_location(location)
             if not data['contract_zone']:
                 raise serializers.ValidationError({'location': ERROR_MSG_NO_CONTRACT_ZONE})
+
+            if start_time or end_time:
+                start_date = localtime(start_time or self.instance.start_time).date()
+                end_date = localtime(end_time or self.instance.end_time).date()
+                zone_unavailable_dates = data['contract_zone'].get_unavailable_dates()
+                unavailable_dates = set(date_range(start_date, end_date)) & set(zone_unavailable_dates)
+                if unavailable_dates:
+                    raise serializers.ValidationError(_('Unavailable dates: {}'.format(sorted(unavailable_dates))))
 
         return data
 

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -3,6 +3,7 @@ from datetime import datetime, time, timedelta
 from django.conf import settings
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.utils import timezone
+from django.utils.timezone import localtime
 from rest_framework.reverse import reverse
 
 from areas.factories import ContractZoneFactory
@@ -210,7 +211,7 @@ def test_event_must_start_before_ending(user_api_client):
 
 def test_new_event_start_must_be_sufficiently_many_calendar_days_in_future(user_api_client, contract_zone):
     full_days_needed = settings.EVENT_MINIMUM_DAYS_BEFORE_START
-    now = timezone.now()
+    now = localtime(timezone.now())
     beginning_of_today = datetime.combine(now.date(), time(tzinfo=now.tzinfo))
 
     # "worst case": event submitted at 00:00, start is the last disallowed minute (at 23:59, full_days_needed later)


### PR DESCRIPTION
This change also means that we will be using everywhere the same logic for
figuring out too early dates.

Closes #36 