### PR TITLE
Switch to netcat-openbsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=appuser:appuser requirements-prod.txt /app/requirements-prod.txt
 
 RUN apt-install.sh \
         git \
-        netcat \
+        netcat-openbsd \
         libpq-dev \
         build-essential \
         gdal-bin \


### PR DESCRIPTION
`netcat` package needs to be switched to `netcat-openbsd` because of Debian Bookworm, which is now used as the base of the Docker image.