### PR TITLE
Address search API endpoint

### DIFF
--- a/areas/api.py
+++ b/areas/api.py
@@ -9,6 +9,7 @@ from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
 
+from areas.digitransit import digitransit_address_search
 from areas.models import ContractZone
 from common.api import UTCModelSerializer
 from events.models import Event
@@ -160,3 +161,20 @@ class ContractZoneViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ContractZone.objects.all()
     serializer_class = ContractZoneSerializer
     filterset_class = ContractZoneFilter
+
+
+class AddressSearchParamSerializer(serializers.Serializer):
+    text = serializers.CharField(required=True)
+    language = serializers.ChoiceField(choices=["fi", "sv", "en"], default="fi")
+
+
+class AddressSearchViewSet(viewsets.ViewSet):
+    def list(self, request, format=None):
+        param_serializer = AddressSearchParamSerializer(data=request.query_params)
+        param_serializer.is_valid(raise_exception=True)
+
+        text = param_serializer.data["text"]
+        language = param_serializer.data["language"]
+        data = digitransit_address_search(text, language)
+
+        return Response(data)

--- a/areas/api.py
+++ b/areas/api.py
@@ -77,8 +77,7 @@ class ContractZoneSerializerGeoQueryView(ContractZoneSerializerBase):
 class GeoQueryViewSet(viewsets.ViewSet):
     def list(self, request, format=None):
         param_serializer = GeoQueryParamSerializer(data=request.query_params)
-        if not param_serializer.is_valid():
-            return Response(param_serializer.errors)
+        param_serializer.is_valid(raise_exception=True)
 
         point = Point(
             param_serializer.validated_data["lon"],

--- a/areas/digitransit.py
+++ b/areas/digitransit.py
@@ -1,0 +1,57 @@
+import requests
+from django.conf import settings
+from typing import Literal
+
+DIGITRANSIT_API_KEY_HEADER = "digitransit-subscription-key"
+
+BOUNDARY_MIN_LAT = "60.1"
+BOUNDARY_MAX_LAT = "60.3"
+BOUNDARY_MIN_LON = "24.73"
+BOUNDARY_MAX_LON = "25.33"
+NUM_OF_RESULTS = 5
+REQUEST_TIMEOUT = 10  # secs
+
+
+class DigitransitApiError(Exception):
+    pass
+
+
+def digitransit_address_search(
+    text: str, language: Literal["fi", "sv", "en"] = "fi"
+) -> dict:
+    try:
+        digitransit_response = requests.get(
+            settings.DIGITRANSIT_ADDRESS_SEARCH_URL,
+            params={
+                "text": text,
+                "lang": language,
+                "boundary.rect.min_lat": BOUNDARY_MIN_LAT,
+                "boundary.rect.max_lat": BOUNDARY_MAX_LAT,
+                "boundary.rect.min_lon": BOUNDARY_MIN_LON,
+                "boundary.rect.max_lon": BOUNDARY_MAX_LON,
+                "size": NUM_OF_RESULTS,
+                "layers": "address",
+            },
+            headers={"digitransit-subscription-key": settings.DIGITRANSIT_API_KEY},
+            timeout=REQUEST_TIMEOUT,
+        )
+        digitransit_response.raise_for_status()
+        digitransit_response_json = digitransit_response.json()
+
+        response = {
+            "type": digitransit_response_json["type"],
+            "features": [
+                {
+                    "type": feature["type"],
+                    "geometry": feature["geometry"],
+                    "properties": {
+                        "name": feature["properties"]["name"],
+                    },
+                }
+                for feature in digitransit_response_json["features"]
+            ],
+        }
+    except (requests.exceptions.RequestException, KeyError) as e:
+        raise DigitransitApiError("Digitransit API request failed:", e) from e
+
+    return response

--- a/areas/tests/test_address_search_api.py
+++ b/areas/tests/test_address_search_api.py
@@ -1,0 +1,307 @@
+import pytest
+import responses
+from responses import matchers
+
+from areas.digitransit import DigitransitApiError
+from common.tests.utils import get
+
+ADDRESS_SEARCH_URL = "/v1/address_search/"
+
+MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL = "http://localhost:9999/digitransit/v1/search"
+MOCK_DIGITRANSIT_API_KEY = "top-secret-test-api-key-123"
+
+COMMON_EXPECTED_DIGITRANSIT_PARAMS = {
+    "boundary.rect.min_lat": "60.1",
+    "boundary.rect.max_lat": "60.3",
+    "boundary.rect.min_lon": "24.73",
+    "boundary.rect.max_lon": "25.33",
+    "size": 5,
+    "layers": "address",
+}
+
+
+@pytest.fixture(autouse=True)
+def mocked_responses(settings):
+    settings.DIGITRANSIT_ADDRESS_SEARCH_URL = MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL
+    settings.DIGITRANSIT_API_KEY = MOCK_DIGITRANSIT_API_KEY
+
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+
+MOCK_RESPONSE = {
+    "geocoding": {
+        "version": "0.2",
+        "attribution": "http://pelias-api:8080/attribution",
+        "query": {
+            "text": "lumikintie",
+            "size": 5,
+            "lang": "fi",
+            "layers": ["address"],
+            "private": False,
+            "boundary.rect.min_lat": 60.1,
+            "boundary.rect.max_lat": 60.3,
+            "boundary.rect.min_lon": 24.73,
+            "boundary.rect.max_lon": 25.33,
+            "boundary.country": ["FIN"],
+            "querySize": 50,
+            "parsed_text": {"name": "lumikintie"},
+        },
+        "engine": {"name": "Pelias", "author": "Mapzen", "version": "1.0"},
+        "timestamp": 1715029813550,
+    },
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.057749, 60.202563]},
+            "properties": {
+                "id": "way:16085704",
+                "gid": "openstreetmap:address:way:16085704",
+                "layer": "address",
+                "source": "openstreetmap",
+                "source_id": "way:16085704",
+                "name": "Lumikintie 4",
+                "housenumber": "4",
+                "street": "Lumikintie",
+                "postalcode": "00820",
+                "postalcode_gid": "whosonfirst:postalcode:421473125",
+                "confidence": 0.9983471074380166,
+                "accuracy": "point",
+                "region": "Uusimaa",
+                "region_gid": "whosonfirst:region:85683067",
+                "localadmin": "Helsinki",
+                "localadmin_gid": "whosonfirst:localadmin:907199715",
+                "locality": "Helsinki",
+                "locality_gid": "whosonfirst:locality:101748417",
+                "neighbourhood": "Roihuvuori",
+                "neighbourhood_gid": "whosonfirst:neighbourhood:1108727173",
+                "label": "Lumikintie 4, Helsinki",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.054729, 60.204275]},
+            "properties": {
+                "id": "way:16085893",
+                "gid": "openstreetmap:address:way:16085893",
+                "layer": "address",
+                "source": "openstreetmap",
+                "source_id": "way:16085893",
+                "name": "Lumikintie 5",
+                "housenumber": "5",
+                "street": "Lumikintie",
+                "postalcode": "00820",
+                "postalcode_gid": "whosonfirst:postalcode:421473125",
+                "confidence": 0.9983471074380166,
+                "accuracy": "point",
+                "region": "Uusimaa",
+                "region_gid": "whosonfirst:region:85683067",
+                "localadmin": "Helsinki",
+                "localadmin_gid": "whosonfirst:localadmin:907199715",
+                "locality": "Helsinki",
+                "locality_gid": "whosonfirst:locality:101748417",
+                "neighbourhood": "Roihuvuori",
+                "neighbourhood_gid": "whosonfirst:neighbourhood:1108727173",
+                "label": "Lumikintie 5, Helsinki",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.055386, 60.202539]},
+            "properties": {
+                "id": "way:16085806",
+                "gid": "openstreetmap:address:way:16085806",
+                "layer": "address",
+                "source": "openstreetmap",
+                "source_id": "way:16085806",
+                "name": "Lumikintie 6",
+                "housenumber": "6",
+                "street": "Lumikintie",
+                "postalcode": "00820",
+                "postalcode_gid": "whosonfirst:postalcode:421473125",
+                "confidence": 0.9983471074380166,
+                "accuracy": "point",
+                "region": "Uusimaa",
+                "region_gid": "whosonfirst:region:85683067",
+                "localadmin": "Helsinki",
+                "localadmin_gid": "whosonfirst:localadmin:907199715",
+                "locality": "Helsinki",
+                "locality_gid": "whosonfirst:locality:101748417",
+                "neighbourhood": "Roihuvuori",
+                "neighbourhood_gid": "whosonfirst:neighbourhood:1108727173",
+                "label": "Lumikintie 6, Helsinki",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.05391, 60.20345]},
+            "properties": {
+                "id": "way:16085874",
+                "gid": "openstreetmap:address:way:16085874",
+                "layer": "address",
+                "source": "openstreetmap",
+                "source_id": "way:16085874",
+                "name": "Lumikintie 7",
+                "housenumber": "7",
+                "street": "Lumikintie",
+                "postalcode": "00820",
+                "postalcode_gid": "whosonfirst:postalcode:421473125",
+                "confidence": 0.9983471074380166,
+                "accuracy": "point",
+                "region": "Uusimaa",
+                "region_gid": "whosonfirst:region:85683067",
+                "localadmin": "Helsinki",
+                "localadmin_gid": "whosonfirst:localadmin:907199715",
+                "locality": "Helsinki",
+                "locality_gid": "whosonfirst:locality:101748417",
+                "neighbourhood": "Roihuvuori",
+                "neighbourhood_gid": "whosonfirst:neighbourhood:1108727173",
+                "label": "Lumikintie 7, Helsinki",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.058641, 60.203472]},
+            "properties": {
+                "id": "way:16085980",
+                "gid": "openstreetmap:address:way:16085980",
+                "layer": "address",
+                "source": "openstreetmap",
+                "source_id": "way:16085980",
+                "name": "Lumikintie 1",
+                "housenumber": "1",
+                "street": "Lumikintie",
+                "postalcode": "00820",
+                "postalcode_gid": "whosonfirst:postalcode:421473125",
+                "confidence": 0.9983471074380166,
+                "accuracy": "point",
+                "region": "Uusimaa",
+                "region_gid": "whosonfirst:region:85683067",
+                "localadmin": "Helsinki",
+                "localadmin_gid": "whosonfirst:localadmin:907199715",
+                "locality": "Helsinki",
+                "locality_gid": "whosonfirst:locality:101748417",
+                "neighbourhood": "Roihuvuori",
+                "neighbourhood_gid": "whosonfirst:neighbourhood:1108727173",
+                "label": "Lumikintie 1, Helsinki",
+            },
+        },
+    ],
+    "bbox": [25.05391, 60.202539, 25.058641, 60.204275],
+}
+
+
+expected_response = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.057749, 60.202563]},
+            "properties": {
+                "name": "Lumikintie 4",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.054729, 60.204275]},
+            "properties": {
+                "name": "Lumikintie 5",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.055386, 60.202539]},
+            "properties": {
+                "name": "Lumikintie 6",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.05391, 60.20345]},
+            "properties": {
+                "name": "Lumikintie 7",
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [25.058641, 60.203472]},
+            "properties": {
+                "name": "Lumikintie 1",
+            },
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "query_string, expected_digitransit_params",
+    [
+        ("text=lumikintie&language=fi", {"text": "lumikintie", "lang": "fi"}),
+        (
+            "text=snövits väg&language=sv",
+            {"text": "snövits väg", "lang": "sv"},
+        ),
+        ("text=lumikintie", {"text": "lumikintie", "lang": "fi"}),
+    ],
+)
+def test_address_search_returns_correct_response_when_digitransit_request_successful(
+    api_client, mocked_responses, query_string, expected_digitransit_params
+):
+    mocked_responses.get(
+        MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL,
+        match=[
+            matchers.query_param_matcher(
+                COMMON_EXPECTED_DIGITRANSIT_PARAMS | expected_digitransit_params
+            ),
+            matchers.header_matcher(
+                {"digitransit-subscription-key": MOCK_DIGITRANSIT_API_KEY}
+            ),
+        ],
+        json=MOCK_RESPONSE,
+        status=200,
+    )
+
+    response = get(api_client, f"{ADDRESS_SEARCH_URL}?{query_string}")
+    assert response == expected_response
+
+
+def test_address_search_returns_error_when_digitransit_responds_http_error(
+    api_client, mocked_responses
+):
+    mocked_responses.get(
+        MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL,
+        json={"error": "some-unknown-error"},
+        status=503,
+    )
+
+    with pytest.raises(DigitransitApiError):
+        get(api_client, ADDRESS_SEARCH_URL + "?text=lumikintie&language=fi")
+
+
+def test_address_search_returns_error_when_digitransit_responds_invalid_json(
+    api_client, mocked_responses
+):
+    mocked_responses.get(
+        MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL,
+        body="no-json",
+        status=200,
+    )
+
+    with pytest.raises(DigitransitApiError) as e:
+        get(api_client, ADDRESS_SEARCH_URL + "?text=lumikintie&language=fi")
+    assert "JSONDecodeError" in str(e)
+
+
+def test_address_search_returns_error_when_digitransit_responds_improper_json(
+    api_client, mocked_responses
+):
+    mocked_responses.get(
+        MOCK_DIGITRANSIT_ADDRESS_SEARCH_URL,
+        json={"foo": "bar"},
+        status=200,
+    )
+
+    with pytest.raises(DigitransitApiError) as e:
+        get(api_client, ADDRESS_SEARCH_URL + "?text=lumikintie&language=fi")
+    assert "KeyError" in str(e)

--- a/areas/tests/test_geo_query_api.py
+++ b/areas/tests/test_geo_query_api.py
@@ -60,7 +60,7 @@ def contract_zone():
 
 
 def test_required_parameters(api_client):
-    response_data = get(api_client, URL)
+    response_data = get(api_client, URL, status_code=400)
     assert all(param in response_data for param in ("lat", "lon"))
 
 

--- a/haravajarjestelma/settings.py
+++ b/haravajarjestelma/settings.py
@@ -53,6 +53,11 @@ env = environ.Env(
     EVENT_REMINDER_DAYS_IN_ADVANCE=(int, 2),
     HELSINKI_WFS_BASE_URL=(str, "https://kartta.hel.fi/ws/geoserver/avoindata/wfs"),
     EXCLUDED_CONTRACT_ZONES=(list, []),
+    DIGITRANSIT_ADDRESS_SEARCH_URL=(
+        str,
+        "https://api.digitransit.fi/geocoding/v1/search",
+    ),
+    DIGITRANSIT_API_KEY=(str, ""),
     LOG_LEVEL=(str, "INFO"),
 )
 if os.path.exists(env_file):
@@ -191,6 +196,9 @@ EVENT_REMINDER_DAYS_IN_ADVANCE = env("EVENT_REMINDER_DAYS_IN_ADVANCE")
 HELSINKI_WFS_BASE_URL = env("HELSINKI_WFS_BASE_URL")
 
 EXCLUDED_CONTRACT_ZONES = env("EXCLUDED_CONTRACT_ZONES")
+
+DIGITRANSIT_ADDRESS_SEARCH_URL = env("DIGITRANSIT_ADDRESS_SEARCH_URL")
+DIGITRANSIT_API_KEY = env("DIGITRANSIT_API_KEY")
 
 CORS_ORIGIN_WHITELIST = env("CORS_ORIGIN_WHITELIST")
 CORS_ORIGIN_ALLOW_ALL = env("CORS_ORIGIN_ALLOW_ALL")

--- a/haravajarjestelma/urls.py
+++ b/haravajarjestelma/urls.py
@@ -3,13 +3,14 @@ from django.http import HttpResponse
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from areas.api import ContractZoneViewSet, GeoQueryViewSet
+from areas.api import AddressSearchViewSet, ContractZoneViewSet, GeoQueryViewSet
 from events.api import EventViewSet
 from users.api import UserViewSet
 
 router = DefaultRouter()
 router.register("event", EventViewSet)
 router.register("geo_query", GeoQueryViewSet, basename="geo_query")
+router.register("address_search", AddressSearchViewSet, basename="address_search")
 router.register("user", UserViewSet)
 router.register("contract_zone", ContractZoneViewSet)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -853,6 +853,76 @@ paths:
                     {"closest_address":{"street":{"name":{"sv":"Postgatan","fi":"Postikatu"}},"distance":24.09049143,"number":"1","number_end":"","letter":"","location":{"type":"Point","coordinates":[24.938211081496277,60.17112410090096]}},"contract_zone":{"id":1,"name":"Hoito
                     1:
                     Keskusta","active":true,"unavailable_dates":["2020-04-21","2020-04-22","2020-04-23","2020-04-24","2020-04-25","2020-04-26","2020-04-27","2020-04-28"]}}
+  /v1/address_search:
+    get:
+      summary: Search for an address
+      description: This endpoint uses Digitransit API address search under the hood.
+      parameters:
+        - name: text
+          in: query
+          description: The text to search for.
+          required: true
+          schema:
+            type: string
+            example: 'Lumikintie'
+        - name: language
+          in: query
+          description: The language to use for the search.
+          required: false
+          schema:
+            type: string
+            enum: [ 'fi', 'sv', 'en' ]
+            default: 'fi'
+            example: 'en'
+      responses:
+        '200':
+          description: Successful operation. The response is a GeoJSON object.
+          content:
+            application/json:
+              schema:
+                type: object
+                format: 'geojson'
+                properties:
+                  type:
+                    type: string
+                  features:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        geometry:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            coordinates:
+                              type: array
+                              items:
+                                type: number
+                        properties:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+              examples:
+                addressSearchExample:
+                  value:
+                    type: "FeatureCollection"
+                    features:
+                      - type: "Feature"
+                        geometry:
+                          type: "Point"
+                          coordinates: [25.057749, 60.202563]
+                        properties:
+                          name: "Lumikintie 4"
+                      - type: "Feature"
+                        geometry:
+                          type: "Point"
+                          coordinates: [25.054729, 60.204275]
+                        properties:
+                          name: "Lumikintie 5"
   /v1/user/{uuid}/:
     get:
       operationId: retrieveUser

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pytest-django
 freezegun
 black
 pip-tools
+responses

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,14 @@ black==24.4.0
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
+certifi==2024.2.2
+    # via
+    #   -c requirements.txt
+    #   requests
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements.txt
+    #   requests
 click==8.1.7
     # via
     #   black
@@ -24,6 +32,10 @@ flake8==7.0.0
     # via -r requirements-dev.in
 freezegun==1.4.0
     # via -r requirements-dev.in
+idna==3.7
+    # via
+    #   -c requirements.txt
+    #   requests
 importlib-metadata==7.1.0
     # via build
 iniconfig==2.0.0
@@ -73,6 +85,16 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   freezegun
+pyyaml==6.0.1
+    # via
+    #   -c requirements.txt
+    #   responses
+requests==2.31.0
+    # via
+    #   -c requirements.txt
+    #   responses
+responses==0.25.0
+    # via -r requirements-dev.in
 six==1.16.0
     # via
     #   -c requirements.txt
@@ -90,6 +112,11 @@ typing-extensions==4.11.0
     # via
     #   -c requirements.txt
     #   black
+urllib3==2.2.1
+    # via
+    #   -c requirements.txt
+    #   requests
+    #   responses
 wheel==0.43.0
     # via pip-tools
 zipp==3.18.1

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,4 @@ sentry-sdk
 drf-oidc-auth
 uwsgi
 pytz
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,6 +159,7 @@ pyyaml==6.0.1
     # via django-munigeo
 requests==2.31.0
     # via
+    #   -r requirements.in
     #   django-anymail
     #   django-helusers
     #   django-munigeo


### PR DESCRIPTION
Added a new API endpoint `/address_search/` which can be used to search addresses with given text and language provided as query params. The result is a GeoJSON containing matching addresses and their coordinates.

Under the hood the search uses [the Digitransit API address search](https://digitransit.fi/en/developers/apis/2-geocoding-api/address-search/). In the past our UI executed address search requests against the Digitransit API directly, but that is not possible anymore as Digitransit started requiring usage of an API key.

The corresponding UI implementation is in [this PR.](https://github.com/City-of-Helsinki/linked-volunteering-ui/pull/189)

Refs: PUIS-134