### PR TITLE
Make address importing work in OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ ENV DEV_SERVER=1
 
 COPY --chown=appuser:appuser . /app/
 
+# django-munigeo municipality importer requires this
+RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod g+w -R /app/data
+
 USER appuser
 
 # ==============================
@@ -41,6 +44,9 @@ FROM appbase as production
 # ==============================
 
 COPY --chown=appuser:appuser . /app/
+
+# django-munigeo municipality importer requires this
+RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod g+w -R /app/data
 
 RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
 


### PR DESCRIPTION
The municipality importer from [Munigeo](https://github.com/City-of-Helsinki/django-munigeo), which is needed to import addresses, writes temporary data to `/app/data` directory. That didn't work in OpenShift because it runs containers with an arbitrary user who doesn't have permission to write to that directory. The recommended way to handle that situation is to allow the root group to write to that directory, and that is exactly what was done.