### PR TITLE
Handle nulls properly in the contract zone importer

### DIFF
--- a/areas/importer/helsinki.py
+++ b/areas/importer/helsinki.py
@@ -2,6 +2,7 @@ import logging
 import urllib
 from django.conf import settings
 from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.gdal.feature import Feature
 from django.db import transaction
 
 from areas.models import ContractZone
@@ -101,7 +102,7 @@ class HelsinkiImporter:
         syncher.finish(force=force)
 
     @staticmethod
-    def _get_attribute_safe(feature, attribute):
+    def _get_attribute_safe(feature: Feature, attribute):
         try:
             value = feature.get(attribute)
         except IndexError:

--- a/areas/importer/helsinki.py
+++ b/areas/importer/helsinki.py
@@ -103,9 +103,10 @@ class HelsinkiImporter:
     @staticmethod
     def _get_attribute_safe(feature, attribute):
         try:
-            return str(feature[attribute])
+            value = feature.get(attribute)
         except IndexError:
-            return ""
+            value = None
+        return str(value).strip() if value is not None else ""
 
     @staticmethod
     def _deactivate_contract_zone(contract_zone):

--- a/areas/tests/data/geojson_simple.json
+++ b/areas/tests/data/geojson_simple.json
@@ -1,0 +1,17 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [102.0, 0.5]},
+            "properties": {
+                "string": "string",
+                "int": 1000,
+                "float": 0.1,
+                "null": null,
+                "boolean": true,
+                "array": [1, 2, 3]
+            }
+        }
+    ]
+}

--- a/areas/tests/test_importer.py
+++ b/areas/tests/test_importer.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from django.contrib.gis.gdal import DataSource
+
+from areas.importer.helsinki import HelsinkiImporter
+
+TEST_DATA = os.path.join(os.path.dirname(__file__), "data")
+
+
+@pytest.fixture
+def ds_geojson_simple():
+    return DataSource(f"{TEST_DATA}/geojson_simple.json")
+
+
+def test_get_attribute_safe_returns_value_as_string(ds_geojson_simple):
+    layer = ds_geojson_simple[0]
+    feature = layer[0]
+    for field in feature.fields:
+        result = HelsinkiImporter._get_attribute_safe(feature, field)
+        assert isinstance(result, str)
+
+
+def test_get_attribute_safe_returns_empty_string_if_attribute_missing(
+    ds_geojson_simple,
+):
+    layer = ds_geojson_simple[0]
+    feature = layer[0]
+    result = HelsinkiImporter._get_attribute_safe(feature, "missing_attribute")
+    assert result == ""
+
+
+def test_get_attribute_safe_returns_empty_string_if_none(ds_geojson_simple):
+    layer = ds_geojson_simple[0]
+    feature = layer[0]
+    result = HelsinkiImporter._get_attribute_safe(feature, "null")
+    assert result == ""


### PR DESCRIPTION
Before this fix, nulls in the source data ended up in our db as `"None"` instead of the correct empty value `""`.

No tests 😞 Adding one for this would have been a bit too much in this situation where there is no existing boilerplate for importer tests. Hopefully importer tests will be implemented for this project someday. But tested manually and works like a charm!

Refs [PS-144](https://helsinkisolutionoffice.atlassian.net/browse/PS-144)

[PS-144]: https://helsinkisolutionoffice.atlassian.net/browse/PS-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ