### PR TITLE
PS-160: require superuser or official for event put delete

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -6,6 +6,7 @@ from areas.models import ContractZone
 from common.api import UTCModelSerializer
 from common.utils import date_range
 from events.models import ERROR_MSG_NO_CONTRACT_ZONE, Event
+from events.permissions import AllowPost, IsOfficial, IsSuperUser, ReadOnly
 
 
 class EventSerializer(UTCModelSerializer):
@@ -59,6 +60,7 @@ class EventViewSet(viewsets.ModelViewSet):
     queryset = Event.objects.all()
     serializer_class = EventSerializer
     filterset_fields = ("contract_zone",)
+    permission_classes = [IsSuperUser | IsOfficial | AllowPost | ReadOnly]
 
     def get_queryset(self):
         return self.queryset.filter_for_user(self.request.user)

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -19,6 +19,17 @@ class AllowPost(BasePermission):
         return request.method == "POST"
 
 
+class AllowStatePatchOnly(BasePermission):
+    """
+    Allows to patch state field only.
+    """
+
+    def has_permission(self, request, view):
+        allowed_fields = ["state"]
+        has_allowed_fields_only = all(field in allowed_fields for field in request.data)
+        return request.method == "PATCH" and has_allowed_fields_only
+
+
 class IsOfficial(BasePermission):
     """
     Allows access only to officials.

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -1,0 +1,41 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class ReadOnly(BasePermission):
+    """
+    Allows read-only operations only.
+    """
+
+    def has_permission(self, request, view):
+        return request.method in SAFE_METHODS
+
+
+class AllowPost(BasePermission):
+    """
+    Allows post method only.
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "POST"
+
+
+class IsOfficial(BasePermission):
+    """
+    Allows access only to officials.
+    """
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and hasattr(request.user, "is_official")
+            and request.user.is_official
+        )
+
+
+class IsSuperUser(BasePermission):
+    """
+    Allows access only to superusers.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_superuser)

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -226,9 +226,9 @@ def test_regular_user_cannot_modify_or_delete_event(
     event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
-    put(user_api_client, url, event_data, 404)
-    patch(user_api_client, url, event_data, 404)
-    delete(user_api_client, url, 404)
+    put(user_api_client, url, event_data, 403)
+    patch(user_api_client, url, event_data, 403)
+    delete(user_api_client, url, 403)
 
 
 def test_contractor_cannot_modify_or_delete_other_than_own_event(
@@ -237,21 +237,21 @@ def test_contractor_cannot_modify_or_delete_other_than_own_event(
     event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
-    put(contractor_api_client, url, event_data, 404)
-    patch(contractor_api_client, url, event_data, 404)
-    delete(contractor_api_client, url, 404)
+    put(contractor_api_client, url, event_data, 403)
+    patch(contractor_api_client, url, event_data, 403)
+    delete(contractor_api_client, url, 403)
 
 
-def test_contractor_can_modify_and_delete_own_event(
+def test_contractor_cannot_modify_and_delete_own_event(
     contractor_api_client, event, make_event_data
 ):
     event_data = make_event_data(contract_zone=event.contract_zone)
     event.contract_zone.contractor_users.add(contractor_api_client.user)
     url = get_detail_url(event)
 
-    put(contractor_api_client, url, event_data)
-    patch(contractor_api_client, url, event_data)
-    delete(contractor_api_client, url)
+    put(contractor_api_client, url, event_data, 403)
+    patch(contractor_api_client, url, event_data, 403)
+    delete(contractor_api_client, url, 403)
 
 
 def test_official_can_modify_and_delete_event(
@@ -263,6 +263,17 @@ def test_official_can_modify_and_delete_event(
     put(official_api_client, url, event_data)
     patch(official_api_client, url, event_data)
     delete(official_api_client, url)
+
+
+def test_superuser_can_modify_and_delete_event(
+    superuser_api_client, event, make_event_data
+):
+    event_data = make_event_data(contract_zone=event.contract_zone)
+    url = get_detail_url(event)
+
+    put(superuser_api_client, url, event_data)
+    patch(superuser_api_client, url, event_data)
+    delete(superuser_api_client, url)
 
 
 def test_event_must_start_before_ending(settings, user_api_client, make_event_data):

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -1,0 +1,71 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+
+from events.permissions import AllowPost, IsOfficial, IsSuperUser, ReadOnly
+from users.factories import UserFactory
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("get", True),
+        ("head", True),
+        ("options", True),
+        ("post", False),
+        ("put", False),
+        ("delete", False),
+    ],
+)
+def test_read_only_permission(rf, method, expected):
+    request = getattr(rf, method)("/foo")
+    assert ReadOnly().has_permission(request, None) is expected
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("post", True),
+        ("get", False),
+        ("head", False),
+        ("options", False),
+        ("put", False),
+        ("delete", False),
+    ],
+)
+def test_allow_post_permission(rf, method, expected):
+    request = getattr(rf, method)("/foo")
+    assert AllowPost().has_permission(request, None) is expected
+
+
+class IsSuperUserTest:
+    def test_anonymous_user_returns_false(self, rf):
+        request = rf.get("/foo")
+        request.user = AnonymousUser()
+        assert IsSuperUser().has_permission(request, None) is False
+
+    def test_regular_user_returns_false(self, rf):
+        request = rf.get("/foo")
+        request.user = UserFactory()
+        assert IsSuperUser().has_permission(request, None) is False
+
+    def test_superuser_returns_true(self, rf):
+        request = rf.get("/foo")
+        request.user = UserFactory(is_superuser=True)
+        assert IsSuperUser().has_permission(request, None) is True
+
+
+class IsOfficialTest:
+    def test_anonymous_user_returns_false(self, rf):
+        request = rf.get("/foo")
+        request.user = AnonymousUser()
+        assert IsOfficial().has_permission(request, None) is False
+
+    def test_regular_user_returns_false(self, rf):
+        request = rf.get("/foo")
+        request.user = UserFactory()
+        assert IsOfficial().has_permission(request, None) is False
+
+    def test_official_user_returns_true(self, rf):
+        request = rf.get("/foo")
+        request.user = UserFactory(is_official=True)
+        assert IsOfficial().has_permission(request, None) is True

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -27,6 +27,11 @@ def official():
 
 
 @pytest.fixture
+def superuser():
+    return UserFactory(is_superuser=True)
+
+
+@pytest.fixture
 def user_api_client(user):
     api_client = APIClient()
     api_client.force_authenticate(user=user)
@@ -47,4 +52,12 @@ def official_api_client(official):
     api_client = APIClient()
     api_client.force_authenticate(user=official)
     api_client.user = official
+    return api_client
+
+
+@pytest.fixture
+def superuser_api_client(superuser):
+    api_client = APIClient()
+    api_client.force_authenticate(user=superuser)
+    api_client.user = superuser
     return api_client


### PR DESCRIPTION
⚠️ **NOTE: DO NOT MERGE BEFORE THE FRONT-END COUNTERPART IS DONE** ⚠️

Require superuser or official status for event view put/delete. This itself is a breaking change, but this also changes the response code for unauthenticated requests/requests with insufficient permissions to 401/403 (from 404).

Also refactor the tests a bit.