### PR TITLE
Fix flaky tests

### DIFF
--- a/areas/factories.py
+++ b/areas/factories.py
@@ -1,4 +1,3 @@
-import factory
 import factory.fuzzy
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from factory.random import randgen
@@ -9,6 +8,8 @@ from .models import ContractZone
 
 class ContractZoneFactory(factory.django.DjangoModelFactory):
     name = factory.Faker("bs")
+    email = factory.Faker("email")
+    secondary_email = factory.Faker("email")
     boundary = factory.Sequence(
         lambda n: MultiPolygon(
             Polygon(

--- a/areas/tests/test_contract_zone_api.py
+++ b/areas/tests/test_contract_zone_api.py
@@ -1,6 +1,5 @@
 import pytest
 from datetime import datetime
-from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.utils.timezone import make_aware
 from rest_framework.reverse import reverse
 
@@ -15,24 +14,7 @@ LIST_URL = reverse("v1:contractzone-list")
 
 @pytest.fixture
 def contract_zone():
-    return ContractZoneFactory(
-        boundary=MultiPolygon(
-            Polygon(((24, 60), (25, 60), (25, 61), (24, 61), (24, 60)))
-        ),
-        contact_person="John Doe",
-        email="john@doe.com",
-        phone="555-1234567",
-    )
-
-
-@pytest.fixture
-def two_events_2018():
-    return EventFactory.create_batch(2)
-
-
-@pytest.fixture
-def two_events_2019():
-    return EventFactory.create_batch(2, start_time=make_aware(datetime(2019, 3, 3)))
+    return ContractZoneFactory()
 
 
 def get_expected_base_data(contract_zone):
@@ -52,17 +34,19 @@ def get_expected_base_data_with_contact_data(contract_zone):
     )
 
 
-def test_get_list_non_official_no_stats_no_contact_info(
-    contract_zone, two_events_2018, user_api_client
-):
+def test_get_list_non_official_no_stats_no_contact_info(contract_zone, user_api_client):
+    EventFactory.create_batch(
+        2, contract_zone=contract_zone, start_time=make_aware(datetime(2018, 3, 3))
+    )
     response_data = get(user_api_client, LIST_URL + "?stats_year=2018")
 
     assert response_data["results"] == [get_expected_base_data(contract_zone)]
 
 
 def test_get_list_official_no_filter_no_stats_check_contact_data(
-    contract_zone, two_events_2018, official_api_client
+    contract_zone, official_api_client
 ):
+    EventFactory.create_batch(2, contract_zone=contract_zone)
     response_data = get(official_api_client, LIST_URL)
 
     assert response_data["results"] == [
@@ -70,18 +54,23 @@ def test_get_list_official_no_filter_no_stats_check_contact_data(
     ]
 
 
-def test_get_list_official_check_stats(
-    contract_zone, two_events_2018, two_events_2019, official_api_client
-):
+def test_get_list_official_check_stats(contract_zone, official_api_client):
+    event_1, event_2 = EventFactory.create_batch(
+        2, contract_zone=contract_zone, start_time=make_aware(datetime(2018, 3, 3))
+    )
+    EventFactory.create_batch(
+        2, contract_zone=contract_zone, start_time=make_aware(datetime(2019, 3, 3))
+    )
     non_approved_event_that_should_be_ignored = EventFactory(
-        estimated_attendee_count=100000, state=Event.WAITING_FOR_APPROVAL
+        estimated_attendee_count=100000,
+        state=Event.WAITING_FOR_APPROVAL,
+        contract_zone=contract_zone,
     )
     assert non_approved_event_that_should_be_ignored.contract_zone == contract_zone
     assert non_approved_event_that_should_be_ignored.start_time.date().year == 2018
 
     response_data = get(official_api_client, LIST_URL + "?stats_year=2018")
 
-    event_1, event_2 = two_events_2018
     expected_data = dict(
         get_expected_base_data_with_contact_data(contract_zone),
         event_count=2,

--- a/areas/tests/test_geo_query_api.py
+++ b/areas/tests/test_geo_query_api.py
@@ -128,7 +128,9 @@ def test_unavailable_dates(
     """
     for event_day in event_days:
         d = make_aware(datetime(2018, 12, event_day, 11))
-        EventFactory(start_time=d, end_time=d + timedelta(hours=1))
+        EventFactory(
+            start_time=d, end_time=d + timedelta(hours=1), contract_zone=contract_zone
+        )
 
     response_data = get(api_client, get_url(60, 24))
     dates = response_data["contract_zone"]["unavailable_dates"][8:]

--- a/events/notifications.py
+++ b/events/notifications.py
@@ -70,8 +70,10 @@ def send_event_reminder_notification(event):
 
     if not contact_emails:
         logger.warning(
-            'Contract zone {} has no contact email so cannot send "event_reminder" notification there.'
-        ).format(event.contract_zone)
+            'Contract zone {} has no contact email so cannot send "event_reminder" notification there.'.format(
+                event.contract_zone
+            )
+        )
         return
 
     for email in contact_emails:

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 
 from areas.factories import ContractZoneFactory
 from common.tests.conftest import *  # noqa
@@ -10,17 +9,9 @@ from ..factories import EventFactory
 
 @pytest.fixture
 def contract_zone():
-    return ContractZoneFactory(
-        boundary=MultiPolygon(
-            Polygon(((24, 60), (25, 60), (25, 61), (24, 61), (24, 60)))
-        ),
-        email="john_contractor@example.com",
-        secondary_email="mike_contractor@example.com",
-    )
+    return ContractZoneFactory()
 
 
 @pytest.fixture
-def event(contract_zone):
-    event = EventFactory(location=Point(24.5, 60.5))
-    assert event.contract_zone == contract_zone
-    return event
+def event():
+    return EventFactory()

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -1,6 +1,5 @@
 import pytest
-from datetime import datetime, time, timedelta
-from django.conf import settings
+from datetime import timedelta
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.utils import timezone
 from django.utils.timezone import localtime
@@ -8,6 +7,7 @@ from freezegun import freeze_time
 from rest_framework.reverse import reverse
 
 from areas.factories import ContractZoneFactory
+from areas.models import ContractZone
 from common.tests.utils import assert_objects_in_results, delete, get, patch, post, put
 from events.factories import EventFactory
 from events.models import Event
@@ -41,26 +41,33 @@ EXPECTED_EVENT_KEYS = {
 
 
 @pytest.fixture
-def event_data():
-    return {
-        "name": "Testitalkoot",
-        "description": "Testitalkoissa haravoidaan ahkerasti.",
-        "start_time": timezone.now() + timedelta(days=8, hours=6),
-        "end_time": timezone.now() + timedelta(days=8, hours=12),
-        "location": {"type": "Point", "coordinates": [24.95, 60.20]},
-        "organizer_first_name": "Matti",
-        "organizer_last_name": "Meikäläinen",
-        "organizer_email": "matti.meikalainen@tut.fi",
-        "organizer_phone": "555-123456",
-        "estimated_attendee_count": 1000,
-        "targets": "Kaikki mikä ei liiku",
-        "maintenance_location": "Kumputie 7",
-        "additional_information": "Ei lisätietoja.",
-        "large_trash_bag_count": 1000,
-        "small_trash_bag_count": 10000,
-        "trash_picker_count": 7,
-        "equipment_information": "Ei lisätietoja tarvikkeista.",
-    }
+def make_event_data():
+    def _make_event_data(*, contract_zone: ContractZone, **kwargs):
+        return {
+            "name": "Testitalkoot",
+            "description": "Testitalkoissa haravoidaan ahkerasti.",
+            "start_time": timezone.now() + timedelta(days=8, hours=6),
+            "end_time": timezone.now() + timedelta(days=8, hours=12),
+            "location": {
+                "type": "Point",
+                "coordinates": contract_zone.boundary[0].centroid.tuple,
+            },
+            "organizer_first_name": "Matti",
+            "organizer_last_name": "Meikäläinen",
+            "organizer_email": "matti.meikalainen@tut.fi",
+            "organizer_phone": "555-123456",
+            "estimated_attendee_count": 1000,
+            "targets": "Kaikki mikä ei liiku",
+            "maintenance_location": "Kumputie 7",
+            "additional_information": "Ei lisätietoja.",
+            "large_trash_bag_count": 1000,
+            "small_trash_bag_count": 10000,
+            "trash_picker_count": 7,
+            "equipment_information": "Ei lisätietoja tarvikkeista.",
+            **kwargs,
+        }
+
+    return _make_event_data
 
 
 @pytest.fixture(autouse=True)
@@ -180,7 +187,9 @@ def test_official_get_detail_check_data(api_client, official, event):
     check_received_event_data(data, event)
 
 
-def test_regular_user_post_new_event(user_api_client, contract_zone, event_data):
+def test_regular_user_post_new_event(user_api_client, contract_zone, make_event_data):
+    event_data = make_event_data(contract_zone=contract_zone)
+
     post(user_api_client, LIST_URL, event_data)
 
     assert Event.objects.count() == 1
@@ -188,7 +197,9 @@ def test_regular_user_post_new_event(user_api_client, contract_zone, event_data)
     check_event_object(new_event, event_data)
 
 
-def test_official_put_event(official_api_client, event, event_data):
+def test_official_put_event(official_api_client, event, make_event_data):
+    event_data = make_event_data(contract_zone=event.contract_zone)
+
     put(official_api_client, get_detail_url(event), event_data)
 
     assert Event.objects.count() == 1
@@ -196,11 +207,10 @@ def test_official_put_event(official_api_client, event, event_data):
     check_event_object(updated_event, event_data)
 
 
-def test_official_patch_event(official_api_client, event, event_data):
+def test_official_patch_event(official_api_client, event):
     event.state = Event.WAITING_FOR_APPROVAL
     event.save(update_fields=("state",))
     old_name = event.name
-    assert old_name != event_data["name"]
 
     patch(official_api_client, get_detail_url(event), {"state": "approved"})
 
@@ -210,7 +220,10 @@ def test_official_patch_event(official_api_client, event, event_data):
     assert updated_event.state == "approved"
 
 
-def test_regular_user_cannot_modify_or_delete_event(user_api_client, event, event_data):
+def test_regular_user_cannot_modify_or_delete_event(
+    user_api_client, event, make_event_data
+):
+    event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
     put(user_api_client, url, event_data, 404)
@@ -219,8 +232,9 @@ def test_regular_user_cannot_modify_or_delete_event(user_api_client, event, even
 
 
 def test_contractor_cannot_modify_or_delete_other_than_own_event(
-    contractor_api_client, event, event_data
+    contractor_api_client, event, make_event_data
 ):
+    event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
     put(contractor_api_client, url, event_data, 404)
@@ -229,8 +243,9 @@ def test_contractor_cannot_modify_or_delete_other_than_own_event(
 
 
 def test_contractor_can_modify_and_delete_own_event(
-    contractor_api_client, event, event_data
+    contractor_api_client, event, make_event_data
 ):
+    event_data = make_event_data(contract_zone=event.contract_zone)
     event.contract_zone.contractor_users.add(contractor_api_client.user)
     url = get_detail_url(event)
 
@@ -239,7 +254,10 @@ def test_contractor_can_modify_and_delete_own_event(
     delete(contractor_api_client, url)
 
 
-def test_official_can_modify_and_delete_event(official_api_client, event, event_data):
+def test_official_can_modify_and_delete_event(
+    official_api_client, event, make_event_data
+):
+    event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
     put(official_api_client, url, event_data)
@@ -247,33 +265,56 @@ def test_official_can_modify_and_delete_event(official_api_client, event, event_
     delete(official_api_client, url)
 
 
-def test_event_must_start_before_ending(user_api_client, event_data):
+def test_event_must_start_before_ending(settings, user_api_client, make_event_data):
     full_days_needed = settings.EVENT_MINIMUM_DAYS_BEFORE_START
-    event_data["start_time"] = timezone.now() + timedelta(
-        days=full_days_needed, hours=6
+    event_data = make_event_data(
+        contract_zone=ContractZoneFactory(),
+        start_time=timezone.now() + timedelta(days=full_days_needed, hours=6),
+        end_time=timezone.now() + timedelta(days=full_days_needed, hours=5),
     )
-    event_data["end_time"] = timezone.now() + timedelta(days=full_days_needed, hours=5)
+
     response_data = post(user_api_client, LIST_URL, event_data, 400)
+
     assert "Event must start before ending" in response_data["non_field_errors"][0]
 
 
-def test_new_event_start_must_be_sufficiently_many_calendar_days_in_future(
-    user_api_client, contract_zone, event_data
+def test_cannot_create_event_if_start_is_before_minimum_full_days_in_future(
+    settings, user_api_client, contract_zone, make_event_data
 ):
     full_days_needed = settings.EVENT_MINIMUM_DAYS_BEFORE_START
-    now = localtime(timezone.now())
-    beginning_of_today = datetime.combine(now.date(), time(tzinfo=now.tzinfo))
-
-    # "worst case": event submitted at 00:00, start is the last disallowed minute (at 23:59, full_days_needed later)
-    event_data["start_time"] = beginning_of_today + timedelta(
+    beginning_of_today = localtime(timezone.now()).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    minute_before_minimum_start = beginning_of_today + timedelta(
         days=full_days_needed, hours=23, minutes=59
     )
-    event_data["end_time"] = event_data["start_time"] + timedelta(hours=6)
+    # "worst case": event submitted at 00:00, start is the last disallowed minute (at 23:59, full_days_needed later)
+    event_data = make_event_data(
+        contract_zone=contract_zone,
+        start_time=minute_before_minimum_start,
+        end_time=minute_before_minimum_start + timedelta(hours=6),
+    )
+
     post(user_api_client, LIST_URL, event_data, 400)
 
+
+def test_can_create_event_if_start_is_minimum_full_days_in_future(
+    settings, user_api_client, contract_zone, make_event_data
+):
+    full_days_needed = settings.EVENT_MINIMUM_DAYS_BEFORE_START
+    beginning_of_today = localtime(timezone.now()).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    midnight_of_minimum_start_day = beginning_of_today + timedelta(
+        days=full_days_needed + 1
+    )
     # event submitted on 00:00, start is the first allowed minute (at 00:00, full_days_needed+1 later)
-    event_data["start_time"] = beginning_of_today + timedelta(days=full_days_needed + 1)
-    event_data["end_time"] = event_data["start_time"] + timedelta(hours=6)
+    event_data = make_event_data(
+        contract_zone=contract_zone,
+        start_time=midnight_of_minimum_start_day,
+        end_time=midnight_of_minimum_start_day + timedelta(hours=6),
+    )
+
     post(user_api_client, LIST_URL, event_data, 201)
 
 
@@ -285,7 +326,9 @@ def test_event_filtering_by_contract_zone(official_api_client, event):
             Polygon(((14, 30), (15, 30), (15, 31), (14, 31), (14, 30)))
         )
     )
-    event_in_another_contract_zone = EventFactory(location=Point(14.5, 30.5))
+    event_in_another_contract_zone = EventFactory(
+        location=Point(14.5, 30.5), contract_zone=another_contract_zone
+    )
     assert event_in_another_contract_zone.contract_zone == another_contract_zone
 
     results = get(
@@ -296,9 +339,9 @@ def test_event_filtering_by_contract_zone(official_api_client, event):
 
 
 def test_event_cannot_be_created_in_approved_state(
-    api_client, contract_zone, event_data
+    api_client, contract_zone, make_event_data
 ):
-    event_data["state"] = Event.APPROVED
+    event_data = make_event_data(contract_zone=contract_zone, state=Event.APPROVED)
 
     post(api_client, LIST_URL, event_data)
 
@@ -307,10 +350,14 @@ def test_event_cannot_be_created_in_approved_state(
 
 
 def test_event_cannot_be_created_when_days_are_full(
-    official_api_client, contract_zone, event_data
+    official_api_client, contract_zone, make_event_data
 ):
+    event_data = make_event_data(contract_zone=contract_zone)
     events = EventFactory.create_batch(
-        3, start_time=event_data["start_time"], end_time=event_data["end_time"]
+        3,
+        contract_zone=contract_zone,
+        start_time=event_data["start_time"],
+        end_time=event_data["end_time"],
     )
     assert all(event.contract_zone == contract_zone for event in events)
 
@@ -319,14 +366,17 @@ def test_event_cannot_be_created_when_days_are_full(
 
 
 def test_event_can_be_modified_when_days_are_full(
-    official_api_client, contract_zone, event_data
+    official_api_client, contract_zone, make_event_data
 ):
+    event_data = make_event_data(contract_zone=contract_zone, name="Modified name")
     events = EventFactory.create_batch(
-        3, start_time=event_data["start_time"], end_time=event_data["end_time"]
+        3,
+        contract_zone=contract_zone,
+        start_time=event_data["start_time"],
+        end_time=event_data["end_time"],
     )
     assert all(event.contract_zone == contract_zone for event in events)
     event = events[0]
-    event_data["name"] = "Modified name"
 
     put(official_api_client, get_detail_url(event), event_data)
 

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -128,12 +128,12 @@ def get_detail_url(event):
     return reverse("v1:event-detail", kwargs={"pk": event.pk})
 
 
-def test_unauthenticated_user_get_list_no_results(event, api_client):
+def test_anonymous_user_get_list_no_results(event, api_client):
     results = get(api_client, LIST_URL)["results"]
     assert len(results) == 0
 
 
-def test_unauthenticated_user_get_detail_404(event, api_client):
+def test_anonymous_user_get_detail_404(event, api_client):
     get(api_client, get_detail_url(event), 404)
 
 
@@ -180,9 +180,7 @@ def test_official_get_detail_check_data(api_client, official, event):
     check_received_event_data(data, event)
 
 
-def test_unauthenticated_user_post_new_event(
-    user_api_client, contract_zone, event_data
-):
+def test_regular_user_post_new_event(user_api_client, contract_zone, event_data):
     post(user_api_client, LIST_URL, event_data)
 
     assert Event.objects.count() == 1
@@ -212,9 +210,7 @@ def test_official_patch_event(official_api_client, event, event_data):
     assert updated_event.state == "approved"
 
 
-def test_unauthenticated_user_cannot_modify_or_delete_event(
-    user_api_client, event, event_data
-):
+def test_regular_user_cannot_modify_or_delete_event(user_api_client, event, event_data):
     url = get_detail_url(event)
 
     put(user_api_client, url, event_data, 404)

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -8,11 +8,13 @@ from users.factories import UserFactory
 
 @pytest.fixture
 def user():
+    """A regular user."""
     return UserFactory()
 
 
 @pytest.fixture
 def contractor():
+    """A regular user that belongs to a contract zone."""
     user = UserFactory()
     contract_zone = ContractZoneFactory()
     contract_zone.contractor_users.add(user)


### PR DESCRIPTION
(Split from #165)

Running `pytest` would work, but not `pytest -k contractor`. This PR makes various fixes to fix the flakiness of the tests and other refactoring.

Also fixes a broken warning that came up while fixing the tests.