### PR TITLE
Increase uwsgi buffer-size

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -10,3 +10,4 @@ processes = 2
 threads = 2
 route = ^/readiness$ donotlog:
 route = ^/healthz$ donotlog:
+buffer-size = 65535


### PR DESCRIPTION
Increasing the buffer-size will allow bigger requests which will allow e.g. to include big lists of AD-group memberships in an authentication token.