### PR TITLE
Allow contract zone contractor info editing in Django admin UI

### DIFF
--- a/areas/admin.py
+++ b/areas/admin.py
@@ -42,16 +42,8 @@ class ContractZoneAdmin(OSMGeoAdmin):
         (_("Users"), {"fields": ("contractor_users",)}),
     )
     readonly_fields = (
-        "active",
         "name",
         "origin_id",
-        "contractor",
-        "contact_person",
-        "phone",
-        "email",
-        "secondary_contact_person",
-        "secondary_phone",
-        "secondary_email",
     )
 
     def formfield_for_dbfield(self, db_field, **kwargs):


### PR DESCRIPTION
Changed contractor info related fields to be editable through admin UI. The reason they were read-only was that they are meant to be updated only automatically using the contract zone import, but practice has shown that there can also needs for manual modifications.