### PR TITLE
Bring back permission to update events for contractors

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -8,8 +8,9 @@ from common.api import UTCModelSerializer
 from common.utils import date_range
 from events.models import ERROR_MSG_NO_CONTRACT_ZONE, Event
 from events.permissions import (
+    AllowPatch,
     AllowPost,
-    AllowStatePatchOnly,
+    AllowPut,
     IsOfficial,
     IsSuperUser,
     ReadOnly,
@@ -70,7 +71,7 @@ class EventViewSet(viewsets.ModelViewSet):
     permission_classes = [
         IsSuperUser
         | IsOfficial
-        | (IsAuthenticated & AllowStatePatchOnly)
+        | (IsAuthenticated & (AllowPut | AllowPatch))
         | AllowPost
         | ReadOnly
     ]

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -19,15 +19,22 @@ class AllowPost(BasePermission):
         return request.method == "POST"
 
 
-class AllowStatePatchOnly(BasePermission):
+class AllowPut(BasePermission):
     """
-    Allows to patch state field only.
+    Allows put method only.
     """
 
     def has_permission(self, request, view):
-        allowed_fields = ["state"]
-        has_allowed_fields_only = all(field in allowed_fields for field in request.data)
-        return request.method == "PATCH" and has_allowed_fields_only
+        return request.method == "PUT"
+
+
+class AllowPatch(BasePermission):
+    """
+    Allows patch method only.
+    """
+
+    def has_permission(self, request, view):
+        return request.method == "PATCH"
 
 
 class IsOfficial(BasePermission):

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -201,8 +201,8 @@ def test_regular_user_cannot_modify_or_delete_event(
     event_data = make_event_data(contract_zone=event.contract_zone)
     url = get_detail_url(event)
 
-    put(user_api_client, url, event_data, 403)
-    patch(user_api_client, url, event_data, 403)
+    put(user_api_client, url, event_data, 404)
+    patch(user_api_client, url, event_data, 404)
     delete(user_api_client, url, 403)
 
 
@@ -220,16 +220,6 @@ class TestContractor:
 
         patch(contractor_api_client, url, {"state": Event.APPROVED}, 200)
 
-    @pytest.mark.parametrize(
-        "patch_data", [{"name": "foo"}, {"state": Event.APPROVED, "name": "foo"}]
-    )
-    def test_cannot_partial_update_other_than_own_event_state(
-        self, contractor_api_client, contractor_event, patch_data
-    ):
-        url = get_detail_url(contractor_event)
-
-        patch(contractor_api_client, url, patch_data, 403)
-
     def test_cannot_partial_update_other_events_state(self, contractor_api_client):
         other_event = EventFactory(
             name="some other contractor's event", state=Event.WAITING_FOR_APPROVAL
@@ -242,13 +232,13 @@ class TestContractor:
         # the payload is otherwise correct)
         patch(contractor_api_client, url, {"state": Event.APPROVED}, 404)
 
-    def test_cannot_update_own_event(
+    def test_can_update_own_event(
         self, contractor_api_client, contractor_event, make_event_data
     ):
         event_data = make_event_data(contract_zone=contractor_event.contract_zone)
         url = get_detail_url(contractor_event)
 
-        put(contractor_api_client, url, event_data, 403)
+        put(contractor_api_client, url, event_data, 200)
 
     def test_cannot_delete_own_event(self, contractor_api_client, contractor_event):
         url = get_detail_url(contractor_event)
@@ -261,7 +251,7 @@ class TestContractor:
         event_data = make_event_data(contract_zone=event.contract_zone)
         url = get_detail_url(event)
 
-        put(contractor_api_client, url, event_data, 403)
+        put(contractor_api_client, url, event_data, 404)
 
     def test_cannot_delete_other_event(self, contractor_api_client, event):
         url = get_detail_url(event)


### PR DESCRIPTION
Related to ticket PS-159 contractors' permission to modify their events was removed. However, it turned out that contractors still need to at least be able to view all the info on the UI's modify event page, and the easiest fix for that is to bring back the whole event modifying ability.

Refs: [PS-184](https://helsinkisolutionoffice.atlassian.net/browse/PS-184)

[PS-184]: https://helsinkisolutionoffice.atlassian.net/browse/PS-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ