### PR TITLE
Replace dependabot reviewers with CODEOWNERS file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,3 @@ updates:
       prefix: "deps"
     # Disable version updates and only allow security updates
     open-pull-requests-limit: 0
-    reviewers:
-      - "City-of-Helsinki/ratkaisutoimiston-backend"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @City-of-Helsinki/ratkaisutoimiston-backend


### PR DESCRIPTION
Dependabot's reviewers option has been deprecated and should be replaced with code owners: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

As a side-effect, this will add the specified code owner as a reviewer for all PRs.

Refs: RATYK-107
