### PR TITLE
PS-284 Validate event availability from the start date only

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import Any
 
 from django.conf import settings
 from django.utils import timezone
@@ -10,7 +11,6 @@ from rest_framework.permissions import IsAuthenticated
 
 from areas.models import ContractZone
 from common.api import UTCModelSerializer
-from common.utils import date_range
 from events.models import ERROR_MSG_NO_CONTRACT_ZONE, Event
 from events.permissions import (
     AllowPatch,
@@ -44,8 +44,14 @@ class EventSerializer(UTCModelSerializer):
             fields["state"].read_only = True
         return fields
 
-    def _validate_time_constraints(self, start_time, end_time):
-        """Validate time-related constraints for the event."""
+    def _validate_time_constraints(
+        self, start_time: datetime | None, end_time: datetime | None
+    ) -> None:
+        """Validate time-related constraints for the event.
+
+        :param start_time: Event start datetime, if provided.
+        :param end_time: Event end datetime, if provided.
+        """
         # PATCH updates only 'state', so check that start and end times are present in
         # the data
         if start_time and end_time:
@@ -69,8 +75,16 @@ class EventSerializer(UTCModelSerializer):
                 )
             )
 
-    def _validate_location(self, data, start_time, end_time):
-        """Validate location and contract zone availability."""
+    def _validate_location(
+        self, data: dict[str, Any], start_time: datetime | None
+    ) -> dict[str, Any]:
+        """Validate location and contract zone availability.
+
+        :param data: Incoming serializer data.
+        :param start_time: Event start datetime, if provided.
+        :return: Updated serializer data.
+        :rtype: dict[str, Any]
+        """
         location = data.get("location")
         if location:
             data["contract_zone"] = ContractZone.objects.get_active_by_location(
@@ -81,26 +95,28 @@ class EventSerializer(UTCModelSerializer):
                     {"location": ERROR_MSG_NO_CONTRACT_ZONE}
                 )
 
-            if start_time or end_time:
-                start_date = localtime(start_time or self.instance.start_time).date()
-                end_date = localtime(end_time or self.instance.end_time).date()
-                zone_unavailable_dates = data["contract_zone"].get_unavailable_dates(
-                    exclude_event=self.instance
+            # Only the start date determines whether the submission is allowed.
+            start_date = localtime(start_time or self.instance.start_time).date()
+            zone_unavailable_dates = data["contract_zone"].get_unavailable_dates(
+                exclude_event=self.instance
+            )
+            if start_date in zone_unavailable_dates:
+                raise serializers.ValidationError(
+                    _("Unavailable dates: {}".format([start_date]))
                 )
-                unavailable_dates = set(date_range(start_date, end_date)) & set(
-                    zone_unavailable_dates
-                )
-                if unavailable_dates:
-                    raise serializers.ValidationError(
-                        _("Unavailable dates: {}".format(sorted(unavailable_dates)))
-                    )
         return data
 
-    def validate(self, data):
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Validate the full serializer payload.
+
+        :param data: Incoming serializer data.
+        :return: Updated serializer data.
+        :rtype: dict[str, Any]
+        """
         start_time = data.get("start_time")
         end_time = data.get("end_time")
         self._validate_time_constraints(start_time, end_time)
-        data = self._validate_location(data, start_time, end_time)
+        data = self._validate_location(data, start_time)
         return data
 
 

--- a/events/tests/test_event_api.py
+++ b/events/tests/test_event_api.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import Any
 
 import pytest
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
@@ -7,7 +8,7 @@ from django.utils.timezone import localtime
 from freezegun import freeze_time
 from rest_framework.reverse import reverse
 
-from areas.factories import ContractZoneFactory
+from areas.factories import BlockedDateFactory, ContractZoneFactory
 from areas.models import ContractZone
 from common.tests.utils import assert_objects_in_results, delete, get, patch, post, put
 from events.factories import EventFactory
@@ -47,7 +48,9 @@ EXPECTED_PUBLIC_EVENT_KEYS = {"name", "start_time", "end_time", "location"}
 
 @pytest.fixture
 def make_event_data():
-    def _make_event_data(*, contract_zone: ContractZone, **kwargs):
+    def _make_event_data(
+        *, contract_zone: ContractZone, **kwargs: Any
+    ) -> dict[str, Any]:
         return {
             "name": "Testitalkoot",
             "description": "Testitalkoissa haravoidaan ahkerasti.",
@@ -134,8 +137,24 @@ def check_event_object(event_obj, event_data):
     assert event_obj.location
 
 
-def get_detail_url(event):
+def get_detail_url(event: Event) -> str:
     return reverse("v1:event-detail", kwargs={"pk": event.pk})
+
+
+def get_multi_day_event_window(settings: Any) -> tuple[datetime, datetime]:
+    """Return a start/end pair for a valid multi-day event submission.
+
+    :param settings: Django test settings fixture.
+    :return: Start and end datetimes for a valid multi-day event.
+    :rtype: tuple[datetime, datetime]
+    """
+    full_days_needed = settings.EVENT_MINIMUM_DAYS_BEFORE_START
+    beginning_of_today = localtime(timezone.now()).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    start_time = beginning_of_today + timedelta(days=full_days_needed + 1, hours=10)
+    end_time = start_time + timedelta(days=2)
+    return start_time, end_time
 
 
 def test_anonymous_user_get_list_approved_events(event, api_client):
@@ -371,6 +390,55 @@ def test_can_create_event_if_start_is_minimum_full_days_in_future(
     post(user_api_client, LIST_URL, event_data, 201)
 
 
+def test_event_cannot_be_created_when_start_day_is_blocked(
+    settings, user_api_client, contract_zone, make_event_data
+):
+    """Reject an event when the start date itself is blocked.
+
+    :param settings: Django test settings fixture.
+    :param user_api_client: Authenticated API client fixture.
+    :param contract_zone: Contract zone used for the event.
+    :param make_event_data: Fixture helper that builds a valid event payload.
+    """
+    start_time, end_time = get_multi_day_event_window(settings)
+    BlockedDateFactory(contract_zone=contract_zone, date=localtime(start_time).date())
+
+    event_data = make_event_data(
+        contract_zone=contract_zone,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    response_data = post(user_api_client, LIST_URL, event_data, 400)
+
+    assert "Unavailable dates" in response_data["non_field_errors"][0]
+
+
+def test_event_can_span_unavailable_day_if_start_day_is_available(
+    settings, user_api_client, contract_zone, make_event_data
+):
+    """Allow a multi-day event when only a later day is blocked.
+
+    :param settings: Django test settings fixture.
+    :param user_api_client: Authenticated API client fixture.
+    :param contract_zone: Contract zone used for the event.
+    :param make_event_data: Fixture helper that builds a valid event payload.
+    """
+    start_time, end_time = get_multi_day_event_window(settings)
+    BlockedDateFactory(
+        contract_zone=contract_zone,
+        date=localtime(start_time).date() + timedelta(days=1),
+    )
+
+    event_data = make_event_data(
+        contract_zone=contract_zone,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    post(user_api_client, LIST_URL, event_data, 201)
+
+
 def test_event_can_be_created_when_three_events_already_exist(
     official_api_client, contract_zone, make_event_data
 ):
@@ -383,6 +451,37 @@ def test_event_can_be_created_when_three_events_already_exist(
     )
 
     post(official_api_client, LIST_URL, event_data, 201)
+
+
+def test_event_can_be_modified_when_later_day_is_blocked(
+    official_api_client, contract_zone, make_event_data
+):
+    """Allow edits when the event start date stays valid.
+
+    :param official_api_client: Authenticated API client with official access.
+    :param contract_zone: Contract zone used for the event.
+    :param make_event_data: Fixture helper that builds a valid event payload.
+    """
+    event_data = make_event_data(contract_zone=contract_zone)
+    event = EventFactory(
+        contract_zone=contract_zone,
+        start_time=event_data["start_time"],
+        end_time=event_data["end_time"],
+    )
+    BlockedDateFactory(
+        contract_zone=contract_zone,
+        date=localtime(event.start_time).date() + timedelta(days=1),
+    )
+
+    patch(
+        official_api_client,
+        get_detail_url(event),
+        {
+            "end_time": event.end_time + timedelta(days=2),
+            "location": event_data["location"],
+        },
+        200,
+    )
 
 
 def test_event_filtering_by_contract_zone(official_api_client, event):


### PR DESCRIPTION
Validate event availability from the start date only so multi-day events are not rejected when a later day is unavailable.

Refs: PS-284

## Summary

PS-284 changes event availability validation so multi-day events are checked against the **start date only**.

This fixes the case where a user can submit a multi-day event, but one of the later days is unavailable and the submission is rejected even though the event starts on a valid day.

The validation logic in the backend was not in sync with the frontend.
Frontend submitted the data and already moved the user to "Thank you for the submission" page, even though backend threw a validation error response.

The validation behavior in the backend also did not match the expected business logic.

## What changed

- Updated event validation to check only the event start date against unavailable dates.
- Kept update behavior consistent when `start_time` is omitted and the instance value is used.
- Added regression coverage for:
  - blocked start date rejects the submission
  - a later blocked day does not reject a multi-day event if the start day is available
  - PATCH/update behavior when `start_time` is not sent

## Verification

- Added regression tests
- Ran `pytest`