### PR TITLE
Improve Django admin NotificationTemplate validation

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -1,7 +1,46 @@
+from django import forms
 from django.contrib import admin
 from django.contrib.gis.admin import GISModelAdmin
+from django.utils.translation import gettext_lazy as _
+from django_ilmoitin.admin import NotificationTemplateAdmin, NotificationTemplateForm
+from django_ilmoitin.models import NotificationTemplate
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
+from .dummy_context import dummy_context
 from .models import Event
+
+
+class ValidatedNotificationTemplateForm(NotificationTemplateForm):
+    def clean(self):
+        cleaned_data = super().clean()
+        template_type = cleaned_data.get("type")
+        if not template_type:
+            return cleaned_data
+
+        context = dummy_context.get(template_type)
+        env = SandboxedEnvironment(
+            trim_blocks=True, lstrip_blocks=True, undefined=StrictUndefined
+        )
+        for field in "subject", "body_html", "body_text":
+            value = cleaned_data.get(field) or ""
+            try:
+                env.from_string(value).render(context)
+            except Exception as e:
+                raise forms.ValidationError(
+                    _("%(field)s: template rendering failed: %(error)s"),
+                    params={"field": field, "error": str(e)},
+                ) from e
+
+        return cleaned_data
+
+
+class ValidatedNotificationTemplateAdmin(NotificationTemplateAdmin):
+    form = ValidatedNotificationTemplateForm
+
+
+admin.site.unregister(NotificationTemplate)
+admin.site.register(NotificationTemplate, ValidatedNotificationTemplateAdmin)
 
 
 @admin.register(Event)

--- a/events/dummy_context.py
+++ b/events/dummy_context.py
@@ -10,6 +10,8 @@ We extend django-ilmoitin's global dummy_context with:
 - Template-specific sample data for each notification type
 """
 
+from datetime import datetime, timezone
+
 from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
 
 from areas.factories import ContractZoneFactory
@@ -34,8 +36,8 @@ sample_event = EventFactory.build(
     organizer_first_name="John",
     organizer_last_name="Doe",
     organizer_phone="+358 50 123 4567",
-    start_time="2024-12-25T10:00:00Z",
-    end_time="2024-12-25T14:00:00Z",
+    start_time=datetime(2024, 12, 25, 10, 0, 0, tzinfo=timezone.utc),
+    end_time=datetime(2024, 12, 25, 14, 0, 0, tzinfo=timezone.utc),
     estimated_attendee_count=15,
     targets="Clean up litter from park paths and picnic areas",
     maintenance_location="Central Park, Helsinki",

--- a/events/dummy_context.py
+++ b/events/dummy_context.py
@@ -50,12 +50,18 @@ sample_event = EventFactory.build(
 )
 
 
-# Update dummy context with sample data
+_event_context = {"event": sample_event}
+
+# Update dummy context with sample data for all notification types
 dummy_context.update(
     {
         COMMON_CONTEXT: get_notification_base_context(),
-        "event_received": {
-            "event": sample_event,
-        },
+        "event_created": _event_context,
+        "event_received": _event_context,
+        "event_approved_to_organizer": _event_context,
+        "event_approved_to_contractor": _event_context,
+        "event_approved_to_official": _event_context,
+        "event_reminder": _event_context,
+        "event_pending_approval_reminder": _event_context,
     }
 )

--- a/events/tests/test_admin.py
+++ b/events/tests/test_admin.py
@@ -1,0 +1,46 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils import translation
+
+from events.admin import ValidatedNotificationTemplateForm
+from events.notifications import NotificationType
+
+
+def call_clean(body_html="", body_text="", subject="Hello"):
+    form = ValidatedNotificationTemplateForm.__new__(ValidatedNotificationTemplateForm)
+    form.cleaned_data = {
+        "type": NotificationType.EVENT_RECEIVED.value,
+        "subject": subject,
+        "body_html": body_html,
+        "body_text": body_text,
+    }
+    with translation.override("fi"):
+        return form.clean()
+
+
+def test_clean_valid_template():
+    call_clean(body_html="{{ event.name }}")
+
+
+def test_clean_invalid_subject_raises_error():
+    with pytest.raises(
+        ValidationError,
+        match="subject: template rendering failed: 'undefined_variable' is undefined",
+    ):
+        call_clean(subject="{{ undefined_variable }}")
+
+
+def test_clean_invalid_body_html_raises_error():
+    with pytest.raises(
+        ValidationError,
+        match="body_html: template rendering failed: 'undefined_variable' is undefined",
+    ):
+        call_clean(body_html="{{ undefined_variable }}")
+
+
+def test_clean_invalid_body_text_raises_error():
+    with pytest.raises(
+        ValidationError,
+        match="body_text: template rendering failed: 'undefined_variable' is undefined",
+    ):
+        call_clean(body_text="{{ undefined_variable }}")

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -69,6 +69,11 @@ msgstr "urakka-alueet"
 msgid "Finnish"
 msgstr "suomi"
 
+#: events/admin.py:32
+#, python-format
+msgid "%(field)s: template rendering failed: %(error)s"
+msgstr "%(field)s: kentässä on virhe: %(error)s"
+
 msgid "Event must start before ending."
 msgstr "Tapahtuman alkuajan täytyy olla ennen sen loppuaikaa."
 


### PR DESCRIPTION
This PR adds runtime validation for template strings for notifications in admin view. The goal is to prevent broken templates from being saved in the first place causing rendering errors later. 