### PR TITLE
fix: change SECURE_REFERRER_POLICY same-site -> origin-when-cross-origin

### DIFF
--- a/haravajarjestelma/settings.py
+++ b/haravajarjestelma/settings.py
@@ -336,3 +336,6 @@ GDPR_API_USER_PROVIDER = "users.gdpr.get_user"
 GDPR_API_DELETER = "users.gdpr.delete_data"
 GDPR_API_QUERY_SCOPE = env("GDPR_API_QUERY_SCOPE")
 GDPR_API_DELETE_SCOPE = env("GDPR_API_DELETE_SCOPE")
+
+# This is required by OSMWidget / openstreetmaps
+SECURE_REFERRER_POLICY = "origin-when-cross-origin"


### PR DESCRIPTION
django defaults to "same-origin" which sends full url to same origin and nothing to cross origin

"origin-when-cross-origin" does the same, but sends basic origin to cross origin

This is needed by openstreetmaps, which requires a valid Referrer header

Refs: PS-294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security headers to ensure proper functionality of map features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->