### PR TITLE
feat: support TILE_URL in admin OSM widget

### DIFF
--- a/areas/admin.py
+++ b/areas/admin.py
@@ -5,6 +5,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.gis.admin import GISModelAdmin
 from django.utils.translation import gettext_lazy as _
 
+from common.widgets import HaravaOSMWidget
+
 from .models import BlockedDate, ContractZone
 
 User = get_user_model()
@@ -41,6 +43,7 @@ class BlockedDateInline(TabularInline):
 @register(ContractZone)
 class ContractZoneAdmin(GISModelAdmin):
     form = ContractZoneModelForm
+    gis_widget = HaravaOSMWidget
     gis_widget_kwargs = {
         "attrs": {
             "default_zoom": 10,

--- a/common/templates/gis/harava-osm.html
+++ b/common/templates/gis/harava-osm.html
@@ -1,0 +1,32 @@
+{% extends "gis/openlayers.html" %}
+{% load l10n %}
+
+{% block options %}
+    {{ block.super }}
+    options['default_lon'] = {{ default_lon|unlocalize }};
+    options['default_lat'] = {{ default_lat|unlocalize }};
+    options['default_zoom'] = {{ default_zoom|unlocalize }};
+{% endblock %}
+
+{# djlint:off #}
+{% block base_layer %}
+    /*
+     * Use Helsinki city raster tiles instead of tile.openstreetmap.org.
+     *
+     * Root cause of the Firefox-only 403 with the default OSMWidget:
+     *   ol.source.OSM sets crossOrigin='anonymous' on tile img elements, which
+     *   puts Firefox into CORS mode (Sec-Fetch-Mode: cors, Origin: HOST).
+     *   OSM's CDN blocks CORS requests from private/localhost origins.  Chrome
+     *   was unaffected because it served tiles from its cache.
+     *
+     * Fix: Helsinki's maptiles CDN (maptiles.api.hel.fi) supports CORS for all
+     *   origins and requires no API key, so the browser requests tiles directly.
+     */
+    var base_layer = new ol.layer.Tile({
+        source: new ol.source.XYZ({
+            url: '{{ tile_url }}',
+            attributions: '\u00a9 <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors \u00a9 <a href="https://www.hel.fi" target="_blank">City of Helsinki</a>',
+        })
+    });
+{% endblock %}
+{# djlint:on #}

--- a/common/widgets.py
+++ b/common/widgets.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.contrib.gis.forms import OSMWidget
+
+
+class HaravaOSMWidget(OSMWidget):
+    """OSM map widget centred on Helsinki railway station with 3D geometry support.
+
+    Uses Helsinki city raster tiles (maptiles.api.hel.fi) instead of the
+    default tile.openstreetmap.org.  This fixes a Firefox-only 403: OpenLayers'
+    ``crossOrigin='anonymous'`` puts Firefox into CORS mode and OSM's CDN
+    blocks requests whose ``Origin`` header is a private/localhost domain.
+    Helsinki's tile CDN supports CORS for all origins and requires no API key.
+
+    The tile URL is configured via the TILE_URL setting.
+    """
+
+    template_name = "gis/harava-osm.html"
+    default_lon = 24.941389
+    default_lat = 60.171944
+    default_zoom = 12.5
+
+    def __init__(self, attrs=None):
+        super().__init__(attrs)
+        self.attrs["tile_url"] = settings.TILE_URL

--- a/events/admin.py
+++ b/events/admin.py
@@ -7,6 +7,8 @@ from django_ilmoitin.models import NotificationTemplate
 from jinja2 import StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
 
+from common.widgets import HaravaOSMWidget
+
 from .dummy_context import dummy_context
 from .models import Event
 
@@ -45,6 +47,7 @@ admin.site.register(NotificationTemplate, ValidatedNotificationTemplateAdmin)
 
 @admin.register(Event)
 class EventAdmin(GISModelAdmin):
+    gis_widget = HaravaOSMWidget
     gis_widget_kwargs = {
         "attrs": {
             "default_zoom": 10,

--- a/haravajarjestelma/settings.py
+++ b/haravajarjestelma/settings.py
@@ -71,6 +71,10 @@ env = environ.Env(
         "https://api.digitransit.fi/geocoding/v1/search",
     ),
     DIGITRANSIT_API_KEY=(str, ""),
+    TILE_URL=(
+        str,
+        "https://maptiles.api.hel.fi/styles/hel-osm-bright-fi/{z}/{x}/{y}.png",
+    ),
     LOG_LEVEL=(str, "INFO"),
     GDPR_API_QUERY_SCOPE=(str, "gdprquery"),
     GDPR_API_DELETE_SCOPE=(str, "gdprdelete"),
@@ -190,6 +194,7 @@ INSTALLED_APPS = [
     "anymail",
     "mailer",
     "social_django",  # For django-admin Keycloak login
+    "common",
     "events",
     "users",
     "areas",
@@ -268,6 +273,7 @@ EXCLUDED_CONTRACT_ZONES = env("EXCLUDED_CONTRACT_ZONES")
 
 DIGITRANSIT_ADDRESS_SEARCH_URL = env("DIGITRANSIT_ADDRESS_SEARCH_URL")
 DIGITRANSIT_API_KEY = env("DIGITRANSIT_API_KEY")
+TILE_URL = env("TILE_URL")
 
 CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_ALL_ORIGINS = env("CORS_ALLOW_ALL_ORIGINS")

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,9 @@ django-parler
 django-parler-rest
 djangorestframework
 djangorestframework-gis
-django~=5.2
+# Note to future Django 6 upgrader:
+# harava-osm.html must be migrated
+django~=5.2 
 drf-oidc-auth
 factory_boy
 helsinki-profile-gdpr-api


### PR DESCRIPTION
Moving to use a configurable TILE_URL which allows using Helsinki maptiles server. The reason behind it being, that OSM tile usage policy requires a Referrer header which is by default dropped by Django from cross site requests.

Implementation is copied from city-infrastructure-platform.

NOTE: This will require migration when migrating to Django 6, the tile layout will change significantly. See

https://github.com/django/django/blob/main/django/contrib/gis/templates /gis/openlayers.html

Refs: PS-294

Co-PR: https://dev.azure.com/City-of-Helsinki/puistotalkoot/_git/puistotalkoot-pipelines/pullrequest/16278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new map experience in admin forms using Helsinki-based map tiles.
  * Event and contract zone editing now use the updated map view.
  * Added support for a configurable tile source for map rendering.

* **Chores**
  * Added the shared app needed for the new mapping components.
  * Included a note about the upcoming Django upgrade requirement for the map template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->