### PR TITLE
PS-298 | Sonar reliability issue fixes

### DIFF
--- a/areas/admin.py
+++ b/areas/admin.py
@@ -15,7 +15,20 @@ User = get_user_model()
 class ContractZoneModelForm(forms.ModelForm):
     class Meta:
         model = ContractZone
-        fields = "__all__"
+        fields = (
+            "origin_id",
+            "name",
+            "boundary",
+            "active",
+            "contractor",
+            "contractor_users",
+            "contact_person",
+            "phone",
+            "email",
+            "secondary_contact_person",
+            "secondary_phone",
+            "secondary_email",
+        )
 
     def clean_boundary(self):
         # Editing the boundary is not allowed after creation

--- a/areas/importer/helsinki.py
+++ b/areas/importer/helsinki.py
@@ -15,15 +15,17 @@ logger = logging.getLogger(__name__)
 
 
 class HelsinkiImporter:
-    def import_contract_zones(self, force=False):
+    @staticmethod
+    def import_contract_zones(force=False):
         logger.info("Importing Helsinki contract zones")
 
-        data_source = self._fetch_contract_zones()
-        self._process_contract_zones(data_source, force)
+        data_source = HelsinkiImporter._fetch_contract_zones()
+        HelsinkiImporter._process_contract_zones(data_source, force)
 
         logger.info("Helsinki contract zone import done!")
 
-    def _fetch_contract_zones(self):
+    @staticmethod
+    def _fetch_contract_zones():
         contract_zone_filter_str = (
             ' AND "nimi" NOT IN ({})'.format(
                 ",".join(f"'{cz}'" for cz in EXCLUDED_CONTRACT_ZONES)
@@ -53,28 +55,31 @@ class HelsinkiImporter:
 
         return data_source
 
+    @staticmethod
     @transaction.atomic
-    def _process_contract_zones(self, data_source, force=False):
+    def _process_contract_zones(data_source, force=False):
         layer = data_source[0]
         syncher = ModelSyncher(
-            ContractZone.objects.all(), lambda x: x.name, self._deactivate_contract_zone
+            ContractZone.objects.all(),
+            lambda x: x.name,
+            HelsinkiImporter._deactivate_contract_zone,
         )
 
         for feat in layer:
             data = {
                 "name": str(feat["nimi"]),
                 "boundary": feat.geom.geos,
-                "contractor": self._get_attribute_safe(feat, "urakoitsija"),
-                "contact_person": self._get_attribute_safe(feat, "talkoot"),
-                "email": self._get_attribute_safe(feat, "talkoot_email"),
-                "phone": self._get_attribute_safe(feat, "talkoot_puh"),
-                "secondary_contact_person": self._get_attribute_safe(
+                "contractor": HelsinkiImporter._get_attribute_safe(feat, "urakoitsija"),
+                "contact_person": HelsinkiImporter._get_attribute_safe(feat, "talkoot"),
+                "email": HelsinkiImporter._get_attribute_safe(feat, "talkoot_email"),
+                "phone": HelsinkiImporter._get_attribute_safe(feat, "talkoot_puh"),
+                "secondary_contact_person": HelsinkiImporter._get_attribute_safe(
                     feat, "talkoot_varahlo"
                 ),
-                "secondary_email": self._get_attribute_safe(
+                "secondary_email": HelsinkiImporter._get_attribute_safe(
                     feat, "talkoot_varahlo_email"
                 ),
-                "secondary_phone": self._get_attribute_safe(
+                "secondary_phone": HelsinkiImporter._get_attribute_safe(
                     feat, "talkoot_varahlo_puh"
                 ),
                 "origin_id": str(feat["id"]),

--- a/areas/models.py
+++ b/areas/models.py
@@ -79,7 +79,7 @@ class ContractZone(SerializableMixin):
             )
         )
 
-        too_early_dates = {date for date in date_range(today, last_too_early_day)}
+        too_early_dates = set(date_range(today, last_too_early_day))
 
         events = self.events.filter(start_time__date__gt=last_too_early_day)
         if exclude_event:
@@ -166,4 +166,4 @@ def get_affected_dates(date):
     while is_vacation_day(end_date + ONE_DAY):
         end_date += ONE_DAY
 
-    return [d for d in date_range(start_date, end_date)]
+    return list(date_range(start_date, end_date))

--- a/common/api.py
+++ b/common/api.py
@@ -1,13 +1,13 @@
 from copy import deepcopy
+from datetime import UTC
 
-import pytz
 from django.db import models
 from rest_framework import serializers
 
 
 class UTCDateTimeField(serializers.DateTimeField):
     def __init__(self, *args, **kwargs):
-        kwargs.update(default_timezone=pytz.UTC)
+        kwargs.update(default_timezone=UTC)
         super().__init__(*args, **kwargs)
 
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -28,7 +28,7 @@ def is_vacation_day(date):
 def assert_to_addresses(*expected_to_addresses, mails=None):
     if mails is None:
         mails = mail.outbox
-    to_addresses = set(m.to[0] for m in mails)
+    to_addresses = {m.to[0] for m in mails}
     expected_to_addresses = set(expected_to_addresses)
     assert to_addresses == expected_to_addresses, (
         f"{to_addresses} does not match {expected_to_addresses}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z "$SKIP_DATABASE_CHECK" ] || [ "$SKIP_DATABASE_CHECK" = "0" ]; then
+if [[ -z "$SKIP_DATABASE_CHECK" || "$SKIP_DATABASE_CHECK" = "0" ]]; then
   until nc -z -v -w30 "$DATABASE_HOST" 5432
   do
     echo "Waiting for postgres database connection..."


### PR DESCRIPTION
Addresses a set of minor SonarQube findings across the codebase:

- **`common/utils.py`**: Replace `set()` constructor with a set comprehension in `assert_to_addresses`
- **`areas/models.py`**: Replace redundant generator comprehensions with direct `set()` / `list()` constructor calls
- **`areas/admin.py`**: Explicitly list `ContractZoneModelForm` fields instead of `"__all__"` to avoid accidentally exposing future model fields
- **`areas/importer/helsinki.py`**: Make `HelsinkiImporter` methods `@staticmethod` since none of them access instance state
- **`common/api.py`**: Replace `pytz.UTC` with `datetime.UTC` (stdlib, Python 3.9+)
- **`docker-entrypoint.sh`**: Use `[[ ]]` for shell condition and quote variable in `rm -rf`

Refs: PS-298